### PR TITLE
parse: support smart quotes, add tests

### DIFF
--- a/parse_test.go
+++ b/parse_test.go
@@ -20,8 +20,11 @@ func TestParseArgDefs(t *testing.T) {
 		{"int float", "15 30.5", []*ArgDef{{Type: Int}, {Type: Float}}, []*ParsedArg{{Value: int64(15)}, {Value: float64(30.5)}}},
 		{"string int", "hey_man 30", []*ArgDef{{Type: String}, {Type: Int}}, []*ParsedArg{{Value: "hey_man"}, {Value: int64(30)}}},
 		{"quoted strings", "first `middle quoted` last", []*ArgDef{{Type: String}, {Type: String}, {Type: String}}, []*ParsedArg{{Value: "first"}, {Value: "middle quoted"}, {Value: "last"}}},
+		{"smart quote strings", "first “middle quoted” last", []*ArgDef{{Type: String}, {Type: String}, {Type: String}}, []*ParsedArg{{Value: "first"}, {Value: "middle quoted"}, {Value: "last"}}},
 		{"escape space", "first\\ still\\ first second", []*ArgDef{{Type: String}, {Type: String}}, []*ParsedArg{{Value: "first still first"}, {Value: "second"}}},
 		{"escape container", "`first \\` still first` second", []*ArgDef{{Type: String}, {Type: String}}, []*ParsedArg{{Value: "first ` still first"}, {Value: "second"}}},
+		{"open smart quote in container", "“first “ still first” second", []*ArgDef{{Type: String}, {Type: String}}, []*ParsedArg{{Value: "first “ still first"}, {Value: "second"}}},
+		{"unclosed container at end", "hello \"world", []*ArgDef{{Type: String}, {Type: String}}, []*ParsedArg{{Value: "hello"}, {Value: "\"world"}}},
 		{"keep escape character", "first\\n second", []*ArgDef{{Type: String}, {Type: String}}, []*ParsedArg{{Value: "first\\n"}, {Value: "second"}}},
 	}
 


### PR DESCRIPTION
Add support for smart quotes as arg containers. Slightly more involved than adding an entry to `ArgContainers` since the open and close runes are not the same - `“”`. Solution here is to just create two parallel arrays that contain open and close runes for containers and refactor the code a bit to work with that.

The added unit tests pass, ran a quick test on YAGPDB as well with my fork - it builds and runs fine with the expected behavior, as far as I could tell.